### PR TITLE
Fix 404 Errors for 2015-08-11-going-from-reading-to-notes.md

### DIFF
--- a/_posts/2015-08-11-going-from-reading-to-notes.md
+++ b/_posts/2015-08-11-going-from-reading-to-notes.md
@@ -5,14 +5,12 @@ summary: My process of taking reading notes and getting them into my zettlekaste
 ---
 
 
-I've [recently been asked](http://zettelkasten.de/posts/getting-
-started/#comments) how I process my notes from my notebook into the
+I've [recently been asked](http://zettelkasten.de/posts/getting-started/#comments) how I process my notes from my notebook into the
 computer.  I make a distinction between the low-friction
 handwritten notes that I create for the purpose of engaging with my
 reading or a lecture and those more organized and polished notes
 that help me actually remember material years down the road.  See
-[here](http://dansheffler.com/blog/2014-07-21-two-goals-of-note-
-taking/) for details.
+[here](http://dansheffler.com/blog/2014-07-21-two-goals-of-note-taking/) for details.
 
 While reading a book or article, I make a note every time I have a
 substantial thought or observation.  I begin by writing the page
@@ -30,15 +28,13 @@ page reference one at a time.  First, I ask myself whether it is
 important that I remember this bit of information long-term.  If
 not, I move on immediately.  Second, I ask myself, "What is the
 *single* idea here?" trying to remember the principle of [one
-thought per note](http://dansheffler.com/blog/2015-08-05-one-
-thought-per-note/).  So I have two possibilities: (1) I need to
+thought per note](http://dansheffler.com/blog/2015-08-05-one-thought-per-note/). So I have two possibilities: (1) I need to
 create a file that captures this single idea or (2) I already have
 a file.  Let's take both these possibilities in turn:
 
 1. This option is more involved since I have to create a new idea
    note.  (This is accomplished easily with [my Sublime Text
-   plugin](http://dansheffler.com/blog/2015-05-11-my-zettelkasten-
-   in-sublime/).)  Let's break this down into steps with a couple
+   plugin](http://dansheffler.com/blog/2015-05-11-my-zettelkasten-in-sublime/).)  Let's break this down into steps with a couple
    screen-shots:
 
 ![Idea Note 1](http://dansheffler.com/images/Plato_-_Tripartition_-_Internal_Conflict_md_—_Notes1.png)


### PR DESCRIPTION
Removed newlines from URLs since these caused the URL to be rendered with spaces where the newlines were. Clicking on the URLs with the spaces lead to pages with 404 Not Found errors. This fixes the 404s. I didn't try to preserve the characters-per-line limit that existed before.